### PR TITLE
[백명규] 게시글 등록 및 좋아요 처리 기능 작성

### DIFF
--- a/src/main/java/skkunion/union2024/account/presentation/AccountController.java
+++ b/src/main/java/skkunion/union2024/account/presentation/AccountController.java
@@ -20,7 +20,7 @@ public class AccountController {
     /**
      * 편리성을 위해 임시로 만든 코드로 제거해줘야 합니다.
      */
-    // private final AccountServiceFacade accountServiceTempFacade;
+    private final AccountServiceTempFacade accountServiceTempFacade;
 
     @PostMapping("/accounts")
     public ResponseEntity<CreateAccountResponse> createAccount(
@@ -31,7 +31,7 @@ public class AccountController {
         String password = accountRequest.password();
 
         // 편의성을 위해 임시로 만든 코드로 Temp가 아닌 다른 코드로 변경해주어야 합니다.
-        accountServiceFacade.createAccountWithEmailVerification(nickname, email, password);
+        accountServiceTempFacade.createAccountWithEmailVerification(nickname, email, password);
         return ResponseEntity.status(CREATED).body(new CreateAccountResponse(nickname, email));
     }
 

--- a/src/main/java/skkunion/union2024/auth/config/AuthenticationConfig.java
+++ b/src/main/java/skkunion/union2024/auth/config/AuthenticationConfig.java
@@ -17,5 +17,7 @@ public class AuthenticationConfig {
         authMatchers.add("/reissue");
         authMatchers.add("/clubs/*");
         authMatchers.add("/clubs/members");
+        authMatchers.add("/boards");
+        authMatchers.add("/boards/like");
     }
 }

--- a/src/main/java/skkunion/union2024/board/domain/ClubBoard.java
+++ b/src/main/java/skkunion/union2024/board/domain/ClubBoard.java
@@ -1,6 +1,7 @@
 package skkunion.union2024.board.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -17,6 +18,7 @@ import static lombok.AccessLevel.PROTECTED;
 public class ClubBoard {
 
     @Id @GeneratedValue(strategy = IDENTITY)
+    @Getter
     @Column(name = "club_board_id")
     private Long id;
 
@@ -43,14 +45,17 @@ public class ClubBoard {
     @Column(nullable = false)
     private Long likes;
 
-    public ClubBoard(String title, String memberEmail, String nickname, String content) {
+    public ClubBoard(String title, String content, Club club, ClubMember clubMember, String memberEmail, String nickname) {
         this.title = title;
+        this.content = content;
+        this.club = club;
+        this.clubMember = clubMember;
         this.memberEmail = memberEmail;
         this.nickname = nickname;
-        this.content = content;
+        this.likes = 0L;
     }
 
-    public static ClubBoard of(String title, String memberEmail, String writerName, String content) {
-        return new ClubBoard(title, memberEmail, writerName, content);
+    public static ClubBoard of(String title,String content, Club club, ClubMember clubMember, String memberEmail, String writerName) {
+        return new ClubBoard(title, content, club, clubMember, memberEmail, writerName);
     }
 }

--- a/src/main/java/skkunion/union2024/board/domain/repository/ClubBoardRepository.java
+++ b/src/main/java/skkunion/union2024/board/domain/repository/ClubBoardRepository.java
@@ -1,0 +1,21 @@
+package skkunion.union2024.board.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+import skkunion.union2024.board.domain.ClubBoard;
+
+public interface ClubBoardRepository extends JpaRepository<ClubBoard, Long> {
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE ClubBoard set likes = likes + 1 WHERE id = :clubBoardId")
+    void increaseLikes(@Param("clubBoardId") Long clubBoardId);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE ClubBoard set likes = likes - 1 WHERE id = :clubBoardId")
+    void decreaseLikes(@Param("clubBoardId") Long clubBoardId);
+}

--- a/src/main/java/skkunion/union2024/board/presentation/BoardController.java
+++ b/src/main/java/skkunion/union2024/board/presentation/BoardController.java
@@ -1,0 +1,36 @@
+package skkunion.union2024.board.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import skkunion.union2024.board.presentation.dto.request.RegisterBoardRequest;
+import skkunion.union2024.board.service.ClubBoardService;
+
+import static org.springframework.http.HttpStatus.*;
+
+
+@RestController
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final ClubBoardService clubBoardService;
+
+    @PostMapping("/boards")
+    public ResponseEntity<Void> registerBoard(@RequestBody RegisterBoardRequest req,
+                                              Authentication authentication) {
+        String email = authentication.getName();
+        clubBoardService.registerClubBoard(req.clubSlug(), email, req.title(), req.content());
+        return ResponseEntity.status(CREATED).build();
+    }
+
+    @PostMapping("/boards/like")
+    public ResponseEntity<Void> likeAction(@RequestParam("boardId") Long boardId,
+                                           @RequestParam("clubSlug") String clubSlug,
+                                           Authentication authentication) {
+        String email = authentication.getName();
+        clubBoardService.namedLockLikeClubBoard(boardId, clubSlug, email);
+
+        return ResponseEntity.status(OK).build();
+    }
+}

--- a/src/main/java/skkunion/union2024/board/presentation/dto/request/RegisterBoardRequest.java
+++ b/src/main/java/skkunion/union2024/board/presentation/dto/request/RegisterBoardRequest.java
@@ -1,0 +1,8 @@
+package skkunion.union2024.board.presentation.dto.request;
+
+public record RegisterBoardRequest(
+        String clubSlug,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/skkunion/union2024/board/service/ClubBoardService.java
+++ b/src/main/java/skkunion/union2024/board/service/ClubBoardService.java
@@ -1,0 +1,85 @@
+package skkunion.union2024.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import skkunion.union2024.board.domain.ClubBoard;
+import skkunion.union2024.board.domain.repository.ClubBoardRepository;
+import skkunion.union2024.club.common.domain.Club;
+import skkunion.union2024.club.common.domain.ClubMember;
+import skkunion.union2024.club.common.domain.repository.ClubMemberRepository;
+import skkunion.union2024.club.common.domain.repository.ClubRepository;
+import skkunion.union2024.global.exception.ClubBoardException;
+import skkunion.union2024.global.exception.exceptioncode.ExceptionCode;
+import skkunion.union2024.like.domain.BoardLike;
+import skkunion.union2024.like.domain.repository.LikeRepository;
+import skkunion.union2024.lock.repository.LockRepository;
+import skkunion.union2024.member.domain.Member;
+import skkunion.union2024.member.domain.repository.MemberRepository;
+
+import java.util.Optional;
+
+import static skkunion.union2024.global.exception.exceptioncode.ExceptionCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class ClubBoardService {
+
+    private final ClubMemberRepository clubMemberRepository;
+    private final ClubBoardRepository clubBoardRepository;
+    private final LikeRepository likeRepository;
+    private final ClubRepository clubRepository;
+    private final MemberRepository memberRepository;
+    private final LockRepository lockRepository;
+
+    @Transactional
+    public void registerClubBoard(String slug, String email,
+                                  String title, String content) {
+        Club findClub = clubRepository.findClubBySlug(slug)
+                .orElseThrow(() -> new ClubBoardException(CLUB_NOT_FOUND));
+        ClubMember findClubMember = getClubMemberWithValidation(slug, email);
+
+        var clubBoard = ClubBoard.of(title, content, findClub, findClubMember, email, findClubMember.getNickName());
+        clubBoardRepository.save(clubBoard);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void likeClubBoard(Long boardId, String slug, String email) {
+        ClubMember clubMember = getClubMemberWithValidation(slug, email);
+        ClubBoard findClubBoard = clubBoardRepository.findById(boardId)
+                .orElseThrow(() -> new ClubBoardException(CLUB_BOARD_NOT_FOUND));
+
+        Optional<BoardLike> findLike =
+                likeRepository.findLikeByClubBoardAndClubMemberId(findClubBoard, clubMember.getId());
+
+        if (findLike.isPresent()) {
+            likeRepository.delete(findLike.get());
+            clubBoardRepository.decreaseLikes(findClubBoard.getId());
+        } else {
+            likeRepository.save(BoardLike.of(findClubBoard, clubMember.getId()));
+            clubBoardRepository.increaseLikes(findClubBoard.getId());
+        }
+    }
+
+    @Transactional
+    public void namedLockLikeClubBoard(Long boardId, String slug, String email) {
+        try {
+            lockRepository.getLock(boardId + slug + email);
+            likeClubBoard(boardId, slug, email);
+        } finally {
+            lockRepository.releaseLock(boardId + slug + email);
+        }
+    }
+
+    private ClubMember getClubMemberWithValidation(String slug, String email) {
+        Club findClub = clubRepository.findClubBySlug(slug)
+                .orElseThrow(() -> new ClubBoardException(CLUB_NOT_FOUND));
+        Member findMember = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ClubBoardException(ACCOUNT_NOT_FOUND));
+        ClubMember findClubMember = clubMemberRepository.findByClubAndMember(findClub, findMember)
+                .orElseThrow(() -> new ClubBoardException(CLUB_MEMBER_NOT_FOUND));
+
+        return findClubMember;
+    }
+}

--- a/src/main/java/skkunion/union2024/global/exception/ClubBoardException.java
+++ b/src/main/java/skkunion/union2024/global/exception/ClubBoardException.java
@@ -1,0 +1,16 @@
+package skkunion.union2024.global.exception;
+
+import org.springframework.http.HttpStatus;
+import skkunion.union2024.global.exception.exceptioncode.ExceptionCode;
+
+public class ClubBoardException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    public ClubBoardException(ExceptionCode exceptionCode) {
+        this.httpStatus = exceptionCode.getHttpStatus();
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+    }
+}

--- a/src/main/java/skkunion/union2024/global/exception/exceptioncode/ExceptionCode.java
+++ b/src/main/java/skkunion/union2024/global/exception/exceptioncode/ExceptionCode.java
@@ -28,7 +28,11 @@ public enum ExceptionCode {
     CLUB_NOT_FOUND(NOT_FOUND, 2002, "존재하지 않는 동아리입니다."),
     CLUB_MEMBER_ALREADY_EXIST(BAD_REQUEST, 2003, "이미 가입된 회원입니다."),
     CLUB_MEMBER_DUPLICATED_NICKNAME(BAD_REQUEST, 2004, "이미 존재하는 닉네임입니다."),
-    CLUB_MEMBER_NOT_FOUND(NOT_FOUND, 2005, "동아리에 가입되어 있지 않은 회원입니다.");
+    CLUB_MEMBER_NOT_FOUND(NOT_FOUND, 2005, "동아리에 가입되어 있지 않은 회원입니다."),
+
+
+    // 3000번 대(보드 관련 코드)
+    CLUB_BOARD_NOT_FOUND(NOT_FOUND, 3001, "게시글이 존재하지 않습니다.");
     private final HttpStatus httpStatus;
     private final int code;
     private final String message;

--- a/src/main/java/skkunion/union2024/like/domain/BoardLike.java
+++ b/src/main/java/skkunion/union2024/like/domain/BoardLike.java
@@ -1,8 +1,11 @@
 package skkunion.union2024.like.domain;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import skkunion.union2024.board.domain.ClubBoard;
+import skkunion.union2024.club.common.domain.ClubMember;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -11,7 +14,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "board_like", indexes = {
-        @Index(name = "idx_board_like", columnList = "board_id, member_email")
+        @Index(name = "idx_board_like", columnList = "club_board_id, club_member_id")
 })
 public class BoardLike {
 
@@ -20,10 +23,19 @@ public class BoardLike {
     @Column(name = "board_like_id")
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "club_board_id")
+    private ClubBoard clubBoard;
+
     @Column(nullable = false)
-    private Long boardId;
+    private Long clubMemberId;
 
-    @Column(nullable = false, length = 40)
-    private String memberEmail;
+    public BoardLike(ClubBoard clubBoard, Long clubMemberId) {
+        this.clubBoard = clubBoard;
+        this.clubMemberId = clubMemberId;
+    }
 
+    public static BoardLike of(ClubBoard clubBoard, Long clubMemberId) {
+        return new BoardLike(clubBoard, clubMemberId);
+    }
 }

--- a/src/main/java/skkunion/union2024/like/domain/repository/LikeRepository.java
+++ b/src/main/java/skkunion/union2024/like/domain/repository/LikeRepository.java
@@ -1,9 +1,15 @@
 package skkunion.union2024.like.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import skkunion.union2024.board.domain.ClubBoard;
 import skkunion.union2024.like.domain.BoardLike;
+
+import java.util.Optional;
 
 @Repository
 public interface LikeRepository extends JpaRepository<BoardLike, Long> {
+    Optional<BoardLike> findLikeByClubBoardAndClubMemberId(ClubBoard clubBoard, Long ClubMemberId);
 }

--- a/src/main/java/skkunion/union2024/lock/Lock.java
+++ b/src/main/java/skkunion/union2024/lock/Lock.java
@@ -1,0 +1,15 @@
+package skkunion.union2024.lock;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+public class Lock {
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+}

--- a/src/main/java/skkunion/union2024/lock/repository/LockRepository.java
+++ b/src/main/java/skkunion/union2024/lock/repository/LockRepository.java
@@ -1,0 +1,13 @@
+package skkunion.union2024.lock.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import skkunion.union2024.lock.Lock;
+
+public interface LockRepository extends JpaRepository<Lock, Long> {
+    @Query(value = "select get_lock(:key, 3000)", nativeQuery = true)
+    void getLock(String key);
+
+    @Query(value = "select release_lock(:key)", nativeQuery = true)
+    void releaseLock(String key);
+}


### PR DESCRIPTION
원래는 원자적 연산으로만 끝내려고 했으나, Like 객체가 있는 지를 조회해 삭제하거나 추가하는 과정에서 트랜잭션 단위로 락을 걸지 않으면 좋아요 요청을 순간적으로 보냈을 때 중복 처리되는 것을 확인함.

이 문제를 해결하기 위해서 락이 필요하다고 생각을 했고, 레디스 같은 분산락도 좋지만 일단은 네임드락으로 걸어놓음. 낙관적 락과 비관적 락을 걸지 않은 이유는 내가 조회하는 데이터에 있는 값을 변경하는 것이 아니기 때문임. 특정 어딘가에 종속되는 게 아닌 논리적인 Lock을 잡을 수 있는 네임드 락이 적합하다고 생각했음.