### PR TITLE
feat: 이메일 재시도 로직을 스케쥴러 방식으로 변경

### DIFF
--- a/src/main/java/skkunion/union2024/Skkunion2024Application.java
+++ b/src/main/java/skkunion/union2024/Skkunion2024Application.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
 @EnableJpaAuditing
+@EnableScheduling
 public class Skkunion2024Application {
 
     public static void main(String[] args) {

--- a/src/main/java/skkunion/union2024/account/presentation/AccountController.java
+++ b/src/main/java/skkunion/union2024/account/presentation/AccountController.java
@@ -28,7 +28,7 @@ public class AccountController {
     /**
      * 편리성을 위해 임시로 만든 코드로 제거해줘야 합니다.
      */
-    private final AccountServiceTempFacade accountServiceTempFacade;
+//    private final AccountServiceTempFacade accountServiceTempFacade;
 
     @PostMapping("/accounts")
     public ResponseEntity<CreateAccountResponse> createAccount(
@@ -39,7 +39,7 @@ public class AccountController {
         String password = accountRequest.password();
 
         // 편의성을 위해 임시로 만든 코드로 Temp가 아닌 다른 코드로 변경해주어야 합니다.
-        accountServiceTempFacade.createAccountWithEmailVerification(nickname, email, password);
+        accountServiceFacade.createAccountWithEmailVerification(nickname, email, password);
         return ResponseEntity.status(CREATED).body(new CreateAccountResponse(nickname, email));
     }
 
@@ -49,14 +49,13 @@ public class AccountController {
     ) {
         String email = resendRequest.email();
         String password = resendRequest.password();
-
         accountServiceFacade.resendEmailVerification(email, password);
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
     @GetMapping("/accounts/{verificationToken}")
     public ResponseEntity<Void> verifyAccount(
-            @PathVariable final String verificationToken
+            @PathVariable("verificationToken") final String verificationToken
     ) {
         accountServiceFacade.tryEmailVerification(verificationToken);
         return ResponseEntity.noContent().build();

--- a/src/main/java/skkunion/union2024/account/service/AccountServiceFacade.java
+++ b/src/main/java/skkunion/union2024/account/service/AccountServiceFacade.java
@@ -42,7 +42,7 @@ public class AccountServiceFacade {
         // 멤버 삭제 규칙 --> 한번 요청하고 패스워드 작성하게 할 것.
         if (!memberService.IsPasswordMatch(findMember,password))
             throw new EmailVerificationException(ACCOUNT_INFO_DOES_NOT_MATCH);
-        memberService.deleteMemberById(findMember.getId());
+        memberService.softDeleteMemberById(findMember.getId());
     }
 
     @Transactional

--- a/src/main/java/skkunion/union2024/account/service/AccountServiceTempFacade.java
+++ b/src/main/java/skkunion/union2024/account/service/AccountServiceTempFacade.java
@@ -47,7 +47,7 @@ public class AccountServiceTempFacade {
         if (!memberService.IsPasswordMatch(findMember,password))
             throw new EmailVerificationException(ACCOUNT_INFO_DOES_NOT_MATCH);
 
-        memberService.deleteMemberById(findMember.getId());
+        memberService.softDeleteMemberById(findMember.getId());
     }
 
     public void resendEmailVerification(String email, String password) {

--- a/src/main/java/skkunion/union2024/auth/config/AuthenticationConfig.java
+++ b/src/main/java/skkunion/union2024/auth/config/AuthenticationConfig.java
@@ -18,6 +18,7 @@ public class AuthenticationConfig {
         authMatchers.add("/clubs/*");
         authMatchers.add("/clubs/members");
         authMatchers.add("/boards");
+        authMatchers.add("/tboards");
         authMatchers.add("/boards/like");
     }
 }

--- a/src/main/java/skkunion/union2024/board/domain/repository/TempClubBoardQueryRepository.java
+++ b/src/main/java/skkunion/union2024/board/domain/repository/TempClubBoardQueryRepository.java
@@ -1,0 +1,54 @@
+package skkunion.union2024.board.domain.repository;
+
+import static skkunion.union2024.board.domain.QClubBoard.clubBoard;
+import static skkunion.union2024.global.util.PageParameterUtils.PAGE_SIZE;
+
+import java.util.List;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import org.springframework.stereotype.Repository;
+
+import skkunion.union2024.board.dto.ClubBoardDto;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class TempClubBoardQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    // index : club_board_club_id_club_board_id(club_id, club_board_id-1)
+    public List<ClubBoardDto> offsetPaging(Long offset, String slug) {
+
+        if (offset == 0L) {
+            return queryFactory
+                    .select(Projections.fields(ClubBoardDto.class,
+                            clubBoard.id,
+                            clubBoard.title,
+                            clubBoard.content,
+                            clubBoard.nickname,
+                            clubBoard.joinedAt))
+                    .from(clubBoard)
+                    .where(clubBoard.club.slug.eq(slug))
+                    .orderBy(clubBoard.club.slug.asc(), clubBoard.id.desc())
+                    .limit(PAGE_SIZE + 1)
+                    .fetch();
+        }
+
+        return queryFactory
+                .select(Projections.fields(ClubBoardDto.class,
+                        clubBoard.id,
+                        clubBoard.title,
+                        clubBoard.content,
+                        clubBoard.nickname,
+                        clubBoard.joinedAt))
+                .from(clubBoard)
+                .where(clubBoard.club.slug.eq(slug))
+                .orderBy(clubBoard.club.slug.asc(), clubBoard.id.desc())
+                .offset(offset)
+                .limit(PAGE_SIZE + 1)
+                .fetch();
+    }
+}

--- a/src/main/java/skkunion/union2024/board/presentation/TempBoardController.java
+++ b/src/main/java/skkunion/union2024/board/presentation/TempBoardController.java
@@ -1,0 +1,37 @@
+package skkunion.union2024.board.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import skkunion.union2024.board.dto.response.ClubBoardResponse;
+import skkunion.union2024.board.presentation.dto.request.RegisterBoardRequest;
+import skkunion.union2024.board.service.ClubBoardService;
+import skkunion.union2024.board.service.TempClubBoardService;
+import skkunion.union2024.global.annotation.AuthMember;
+import skkunion.union2024.member.dto.AuthMemberDto;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+public class TempBoardController {
+
+    private final TempClubBoardService clubBoardService;
+
+    @GetMapping("/tboards")
+    public ResponseEntity<ClubBoardResponse> getClubBoard(
+            @RequestParam("clubSlug") String clubSlug,
+            @RequestParam(value = "page", required = false) Long page,
+            @AuthMember AuthMemberDto authMemberDto) {
+
+        if (page == null) {
+            page = 0L;
+        } else {
+            page = page * 15;
+        }
+        ClubBoardResponse clubBoards
+                = clubBoardService.getClubBoardWithOffset(clubSlug, authMemberDto.memberId(), page);
+        return ResponseEntity.status(OK).body(clubBoards);
+    }
+}

--- a/src/main/java/skkunion/union2024/board/service/TempClubBoardService.java
+++ b/src/main/java/skkunion/union2024/board/service/TempClubBoardService.java
@@ -1,0 +1,81 @@
+package skkunion.union2024.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import skkunion.union2024.board.domain.ClubBoard;
+import skkunion.union2024.board.domain.repository.ClubBoardQueryRepository;
+import skkunion.union2024.board.domain.repository.ClubBoardRepository;
+import skkunion.union2024.board.domain.repository.TempClubBoardQueryRepository;
+import skkunion.union2024.board.dto.ClubBoardDto;
+import skkunion.union2024.board.dto.response.ClubBoardResponse;
+import skkunion.union2024.club.common.domain.Club;
+import skkunion.union2024.club.common.domain.ClubMember;
+import skkunion.union2024.club.common.domain.repository.ClubMemberRepository;
+import skkunion.union2024.club.common.domain.repository.ClubRepository;
+import skkunion.union2024.global.exception.ClubBoardException;
+import skkunion.union2024.like.domain.BoardLike;
+import skkunion.union2024.like.domain.repository.LikeRepository;
+import skkunion.union2024.member.domain.Member;
+import skkunion.union2024.member.domain.repository.MemberRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static skkunion.union2024.global.exception.exceptioncode.ExceptionCode.*;
+import static skkunion.union2024.global.util.PageParameterUtils.*;
+
+@Service
+@RequiredArgsConstructor
+public class TempClubBoardService {
+    private final ClubMemberRepository clubMemberRepository;
+    private final ClubBoardRepository clubBoardRepository;
+    private final LikeRepository likeRepository;
+    private final ClubRepository clubRepository;
+    private final MemberRepository memberRepository;
+    private final TempClubBoardQueryRepository clubBoardQueryRepository;
+
+    @Transactional(readOnly = true)
+    public ClubBoardResponse getClubBoardWithOffset(String slug, Long memberId, Long offset) {
+        getClubMemberWithValidation(slug, memberId);
+
+        List<ClubBoardDto> clubBoardDtos = clubBoardQueryRepository.offsetPaging(offset, slug);
+        boolean hasNext = hasNext(clubBoardDtos);
+        int size = getSize(clubBoardDtos);
+
+        Long nextCursorId = null;
+        if (hasNext) {
+            clubBoardDtos.remove(size);
+            nextCursorId = getLongCursor(clubBoardDtos, ClubBoardDto::getId);
+        }
+        return new ClubBoardResponse(slug, size, hasNext, nextCursorId, clubBoardDtos);
+    }
+
+    private ClubMember getClubMemberWithClubAndMember(Club club, Member member) {
+        return clubMemberRepository.findByClubAndMember(club, member)
+                                   .orElseThrow(() -> new ClubBoardException(CLUB_MEMBER_NOT_FOUND));
+    }
+
+    private ClubMember getClubMemberWithValidation(String slug, Long memberId) {
+        Club club = getClubBySlug(slug);
+        Member member = getMemberById(memberId);
+        return clubMemberRepository.findByClubAndMember(club, member)
+                                   .orElseThrow(() -> new ClubBoardException(CLUB_MEMBER_NOT_FOUND));
+    }
+
+    private Club getClubBySlug(String slug) {
+        return clubRepository.findClubBySlug(slug)
+                             .orElseThrow(() -> new ClubBoardException(CLUB_NOT_FOUND));
+    }
+
+    private ClubBoard getClubBoardById(Long boardId) {
+        return clubBoardRepository.findById(boardId)
+                                  .orElseThrow(() -> new ClubBoardException(CLUB_BOARD_NOT_FOUND));
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                               .orElseThrow(() -> new ClubBoardException(ACCOUNT_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/skkunion/union2024/email/verification/config/AsyncConfig.java
+++ b/src/main/java/skkunion/union2024/email/verification/config/AsyncConfig.java
@@ -9,7 +9,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @Configuration
 public class AsyncConfig {
 
-    private static final int CORE_POOL_SIZE = 10;
+    private static final int CORE_POOL_SIZE = 8;
     private static final int MAX_POOL_SIZE = 50;
     private static final int QUEUE_CAPACITY = 20;
 

--- a/src/main/java/skkunion/union2024/email/verification/domain/EmailSendRecord.java
+++ b/src/main/java/skkunion/union2024/email/verification/domain/EmailSendRecord.java
@@ -1,0 +1,34 @@
+package skkunion.union2024.email.verification.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "email_send_record")
+public class EmailSendRecord {
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "email_send_record_id")
+    private Long id;
+
+    @Column(nullable = false, length = 40, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private Integer count;
+
+    private EmailSendRecord(String email) {
+        this.email = email;
+        this.count = 1;
+    }
+
+    public static EmailSendRecord of(String email) {
+        return new EmailSendRecord(email);
+    }
+}

--- a/src/main/java/skkunion/union2024/email/verification/domain/EmailVerification.java
+++ b/src/main/java/skkunion/union2024/email/verification/domain/EmailVerification.java
@@ -22,7 +22,7 @@ public class EmailVerification {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 40)
+    @Column(nullable = false, length = 40, unique = true)
     private String email;
 
     @Column(nullable = false, length = 10)

--- a/src/main/java/skkunion/union2024/email/verification/domain/repository/EmailSendRecordQueryRepository.java
+++ b/src/main/java/skkunion/union2024/email/verification/domain/repository/EmailSendRecordQueryRepository.java
@@ -1,0 +1,33 @@
+package skkunion.union2024.email.verification.domain.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import skkunion.union2024.email.verification.domain.EmailSendRecord;
+
+import java.util.List;
+
+import static skkunion.union2024.email.verification.domain.QEmailSendRecord.emailSendRecord;
+import static skkunion.union2024.global.util.PageParameterUtils.SCHEDULE_PAGE_SIZE;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailSendRecordQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public List<EmailSendRecord> findEmailRecordsById(Long recordId) {
+        BooleanBuilder dynamicLtId = new BooleanBuilder();
+
+        if (recordId != null) {
+            dynamicLtId.and(emailSendRecord.id.lt(recordId));
+        }
+
+        return queryFactory
+                .selectFrom(emailSendRecord)
+                .where(dynamicLtId)
+                .orderBy(emailSendRecord.id.asc())
+                .limit(SCHEDULE_PAGE_SIZE)
+                .fetch();
+    }
+}

--- a/src/main/java/skkunion/union2024/email/verification/domain/repository/EmailSendRecordRepository.java
+++ b/src/main/java/skkunion/union2024/email/verification/domain/repository/EmailSendRecordRepository.java
@@ -1,0 +1,22 @@
+package skkunion.union2024.email.verification.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+import skkunion.union2024.email.verification.domain.EmailSendRecord;
+
+import java.util.Optional;
+
+public interface EmailSendRecordRepository extends JpaRepository<EmailSendRecord, Long> {
+    Optional<EmailSendRecord> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+    @Modifying
+    @Transactional
+    @Query("update EmailSendRecord set count = count + 1 where email = :email")
+    void increaseCount(String email);
+
+    void deleteByEmail(String email);
+}

--- a/src/main/java/skkunion/union2024/email/verification/domain/repository/EmailVerificationRepository.java
+++ b/src/main/java/skkunion/union2024/email/verification/domain/repository/EmailVerificationRepository.java
@@ -21,7 +21,6 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
 
     void deleteByToken(String token);
 
-
     @Modifying
     @Query("""
             UPDATE EmailVerification emailVerification

--- a/src/main/java/skkunion/union2024/email/verification/service/EmailSendRecordService.java
+++ b/src/main/java/skkunion/union2024/email/verification/service/EmailSendRecordService.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import skkunion.union2024.email.verification.domain.EmailSendRecord;
+import skkunion.union2024.email.verification.domain.repository.EmailSendRecordQueryRepository;
 import skkunion.union2024.email.verification.domain.repository.EmailSendRecordRepository;
 import skkunion.union2024.member.service.MemberService;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -15,6 +17,7 @@ public class EmailSendRecordService {
 
     private final MemberService memberService;
     private final EmailSendRecordRepository emailSendRecordRepository;
+    private final EmailSendRecordQueryRepository emailSendRecordQueryRepository;
 
     @Transactional
     public void recordSaveOrIncreaseCount(String email) {
@@ -26,13 +29,19 @@ public class EmailSendRecordService {
             } else {
                 emailSendRecordRepository.increaseCount(email);
             }
+        } else {
+            emailSendRecordRepository.save(EmailSendRecord.of(email));
         }
 
-        emailSendRecordRepository.save(EmailSendRecord.of(email));
     }
 
     @Transactional
     public void deleteRecordByEmail(String email) {
         emailSendRecordRepository.deleteByEmail(email);
+    }
+
+    @Transactional
+    public List<EmailSendRecord> emailSendRecordsByCursor(Long recordId) {
+        return emailSendRecordQueryRepository.findEmailRecordsById(recordId);
     }
 }

--- a/src/main/java/skkunion/union2024/email/verification/service/EmailSendRecordService.java
+++ b/src/main/java/skkunion/union2024/email/verification/service/EmailSendRecordService.java
@@ -1,0 +1,38 @@
+package skkunion.union2024.email.verification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import skkunion.union2024.email.verification.domain.EmailSendRecord;
+import skkunion.union2024.email.verification.domain.repository.EmailSendRecordRepository;
+import skkunion.union2024.member.service.MemberService;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EmailSendRecordService {
+
+    private final MemberService memberService;
+    private final EmailSendRecordRepository emailSendRecordRepository;
+
+    @Transactional
+    public void recordSaveOrIncreaseCount(String email) {
+        Optional<EmailSendRecord> findRecord = emailSendRecordRepository.findByEmail(email);
+        if (findRecord.isPresent()) {
+            if (findRecord.get().getCount() == 5) {
+                emailSendRecordRepository.delete(findRecord.get());
+                memberService.completeDeleteByEmail(email);
+            } else {
+                emailSendRecordRepository.increaseCount(email);
+            }
+        }
+
+        emailSendRecordRepository.save(EmailSendRecord.of(email));
+    }
+
+    @Transactional
+    public void deleteRecordByEmail(String email) {
+        emailSendRecordRepository.deleteByEmail(email);
+    }
+}

--- a/src/main/java/skkunion/union2024/email/verification/service/EmailSendSchedulerService.java
+++ b/src/main/java/skkunion/union2024/email/verification/service/EmailSendSchedulerService.java
@@ -1,0 +1,34 @@
+package skkunion.union2024.email.verification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import skkunion.union2024.email.verification.domain.EmailSendRecord;
+
+import java.util.List;
+
+import static skkunion.union2024.global.util.PageParameterUtils.SCHEDULE_PAGE_SIZE;
+
+@Service
+@RequiredArgsConstructor
+public class EmailSendSchedulerService {
+    private final EmailSendRecordService emailSendRecordService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void executePagingEmailSendRecord() {
+
+        List<EmailSendRecord> emailSendRecords = null;
+        do {
+            if (emailSendRecords == null) {
+                emailSendRecords = emailSendRecordService.emailSendRecordsByCursor(null);
+            } else {
+                Long lastRecordId = emailSendRecords.get(emailSendRecords.size() - 1).getId();
+                emailSendRecords = emailSendRecordService.emailSendRecordsByCursor(lastRecordId);
+            }
+            emailSendRecords.forEach(emailSendRecord -> {
+               emailSendRecordService.recordSaveOrIncreaseCount(emailSendRecord.getEmail());
+            });
+        } while (emailSendRecords.size() >= SCHEDULE_PAGE_SIZE);
+
+    }
+}

--- a/src/main/java/skkunion/union2024/global/util/PageParameterUtils.java
+++ b/src/main/java/skkunion/union2024/global/util/PageParameterUtils.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 public class PageParameterUtils<T, R> {
 
     public static Integer PAGE_SIZE = 15;
+    public static Integer SCHEDULE_PAGE_SIZE = 50;
 
     public static <T> boolean hasNext(List<T> pageObject) {
         return pageObject.size() > PAGE_SIZE;

--- a/src/main/java/skkunion/union2024/member/domain/Member.java
+++ b/src/main/java/skkunion/union2024/member/domain/Member.java
@@ -33,7 +33,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@SQLDelete(sql = "UPDATE member SET status = 'DELETED' WHERE id = ?")
+@SQLDelete(sql = "UPDATE member SET status = 'DELETED' WHERE member_id = ?")
 public class Member {
 
     @Id

--- a/src/main/java/skkunion/union2024/member/domain/repository/MemberRepository.java
+++ b/src/main/java/skkunion/union2024/member/domain/repository/MemberRepository.java
@@ -41,4 +41,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         WHERE member.id = :memberId
         """)
     void deleteCompleteById(@Param("memberId") final Long memberId);
+
+    @Modifying
+    @Query("""
+        DELETE from Member member
+        WHERE member.email = :email
+        """)
+    void deleteCompleteByEmail(@Param("email") final String email);
 }

--- a/src/main/java/skkunion/union2024/member/domain/repository/MemberRepository.java
+++ b/src/main/java/skkunion/union2024/member/domain/repository/MemberRepository.java
@@ -14,6 +14,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsMemberByEmail(String email);
 
+    boolean existsMemberByNickname(String nickname);
+
     Optional<Member> findByEmail(String email);
 
     @Modifying

--- a/src/main/java/skkunion/union2024/member/service/MemberService.java
+++ b/src/main/java/skkunion/union2024/member/service/MemberService.java
@@ -58,6 +58,11 @@ public class MemberService {
         return memberRepository.existsMemberByEmail(email);
     }
 
+    @Transactional(readOnly = true)
+    public boolean isMemberExistWithNickname(String nickname) {
+        return memberRepository.existsMemberByNickname(nickname);
+    }
+
     public boolean IsPasswordMatch(Member member, String password) {
         return passwordEncoder.matches(password, member.getPassword());
     }

--- a/src/main/java/skkunion/union2024/member/service/MemberService.java
+++ b/src/main/java/skkunion/union2024/member/service/MemberService.java
@@ -26,12 +26,17 @@ public class MemberService {
     }
 
     @Transactional
-    public void deleteMemberById(Long memberId) {
+    public void softDeleteMemberById(Long memberId) {
         memberRepository.deleteSoftById(memberId);
     }
 
     @Transactional
-    public void completeDelete(Long memberId) {
+    public void completeDeleteByEmail(String email) {
+        memberRepository.deleteCompleteByEmail(email);
+    }
+
+    @Transactional
+    public void completeDeleteById(Long memberId) {
         Member findMember = findMemberById(memberId).orElseThrow(()
                 -> new EmailVerificationException(ExceptionCode.ACCOUNT_NOT_FOUND));
 


### PR DESCRIPTION
JavaMailSender의 특성상 재시도 로직보다는 스케줄러를 통해 하루 치 작업을 처리한 뒤 계정을 삭제하는 게 좋을 거라 생각함.
이를 위해서 Email 전송에 관한 반복 횟수를 기록하는 테이블을 하나 따로 만듦.

또한, TheadPoolExecutor에 관한 이해의 결과, 최대 쓰레드로 늘어나는 기준과 이후 버려지는 예외 작업에 관한 처리에 대한 변경이 필요할 거라 생각했음. 그 결과 queue에 쌓이는 작업의 수는 줄이고, 최대 쓰레드 개수에 관해 변경을 함. 사실 서버가 여러 대라면 DB를 중심으로 전용 커넥션만 가져오면 되는 것이니 그렇게 확장을 할 수도 있을 거라 생각함. 또한, 위의 동작은 queue가 가득 차서 작업을 버리더라도 상관없이 동작함.